### PR TITLE
Update catppuccin-theme.el

### DIFF
--- a/catppuccin-theme.el
+++ b/catppuccin-theme.el
@@ -1179,13 +1179,13 @@ FLAVOR defaults to the value of `catppuccin-flavor'."
          (slime-repl-inputed-output-face :foreground ,ctp-mauve)
 
          ;; smerge
-         (smerge-lower :inherit diff-added :background nil)
-         (smerge-upper :inherit diff-removed :background nil)
+         (smerge-lower :inherit diff-added :background unspecified)
+         (smerge-upper :inherit diff-removed :background unspecified)
          (smerge-refined-added :inherit diff-refine-added
-           :background nil)
+           :background unspecified)
          (smerge-refined-removed :inherit diff-refine-removed
-           :background nil)
-         (smerge-base :inherit diff-refine-changed :background nil)
+           :background unspecified)
+         (smerge-base :inherit diff-refine-changed :background unspecified)
 
          ;; swiper
          ;;(swiper-line-face :inherit swiper-match-face-1)


### PR DESCRIPTION
Updates the smerge faces to use unspecified rather than nil to avoid warnings in the emacs message buffer

### Old:

<!--Provide a screenshot of the original issue if applicable:
![{103A4D3C-606B-40B8-9719-22294CC6A1E4}](https://github.com/user-attachments/assets/83157a87-4b82-4975-9c25-06ee35af86dc)
-->

### New:

<!--Provide a screenshot of your changes if applicable:
  ![original-screenshot-here](Please)
-->
